### PR TITLE
Add news data from new SF news scraper script

### DIFF
--- a/components/WhatsNew.vue
+++ b/components/WhatsNew.vue
@@ -16,9 +16,9 @@
         >
           <time
             class="WhatsNew-list-item-anchor-time px-2"
-            :datetime="formattedDate(item.date)"
+            :datetime="item.date"
           >
-            {{ item.date }}
+            {{ humanDate(item.date) }}
           </time>
           <span class="WhatsNew-list-item-anchor-link">
             {{ item.text }}
@@ -37,7 +37,7 @@
 </template>
 
 <script>
-import { convertDateToISO8601Format } from '@/utils/formatDate'
+import { convertISO8601ToHumanDateFormat } from '@/utils/formatDate'
 
 export default {
   props: {
@@ -50,8 +50,8 @@ export default {
     isInternalLink(path) {
       return !/^https?:\/\//.test(path)
     },
-    formattedDate(dateString) {
-      return convertDateToISO8601Format(dateString)
+    humanDate(isoDate) {
+      return convertISO8601ToHumanDateFormat(isoDate)
     }
   }
 }
@@ -93,7 +93,7 @@ export default {
       }
 
       &-time {
-        flex: 0 0 90px;
+        flex: 0 0 95px;
         @include lessThan($medium) {
           flex: 0 0 100%;
         }

--- a/data/news.json
+++ b/data/news.json
@@ -1,34 +1,54 @@
 {
   "newsItems": [
     {
-      "date": "04/17/2020",
+      "url": "https://sf.gov/news/expansion-coronavirus-testing-all-essential-workers-sf",
+      "text": "Expansion of coronavirus testing for all essential workers in SF",
+      "date": "2020-04-23T04:11:56Z"
+    },
+    {
+      "url": "https://sf.gov/news/sfmta-starts-closing-some-sf-streets-promote-safety-and-physical-distancing",
+      "text": "SFMTA starts closing some SF streets to promote safety and physical distancing",
+      "date": "2020-04-21T21:05:46Z"
+    },
+    {
       "url": "https://sf.gov/news/sf-issues-new-policy-face-coverings",
-      "text": "SF issues new policy on face coverings for the coronavirus outbreak."
+      "text": "SF issues new policy on face coverings for the coronavirus outbreak",
+      "date": "2020-04-17T20:15:11Z"
     },
     {
-      "date": "04/15/2020",
-      "url": "https://sf.gov/news/san-francisco-will-hold-states-discriminatory-laws-accountable",
-      "text": "San Francisco will hold states with discriminatory laws accountable"
-    },
-    {
-      "date": "04/06/2020",
       "url": "https://sf.gov/news/sfmta-reduces-service-down-17-lines-due-covid-19-outbreak",
-      "text": "SFMTA reduces service down to 17 lines due to COVID-19 outbreak."
+      "text": "SFMTA reduces service down to 17 lines due to COVID-19 outbreak",
+      "date": "2020-04-06T16:40:26Z"
     },
     {
-      "date": "03/30/2020",
-      "url": "https://sf.gov/news/about-citys-temporary-moratorium-evictions",
-      "text": "About the City's temporary moratorium on evictions"
+      "url": "https://sf.gov/news/sf-expands-stay-home-order-response-coronavirus-outbreak",
+      "text": "SF expands the Stay Home order in response to the coronavirus outbreak",
+      "date": "2020-03-31T22:06:03Z"
     },
     {
-      "date": "03/27/2020",
-      "url": "https://sf.gov/stay-home-except-essential-needs",
-      "text": "Stay home during the coronavirus outbreak"
+      "url": "https://sf.gov/news/sf-responds-coronavirus-outbreak-stay-home-order",
+      "text": "SF responds to coronavirus outbreak with Stay Home order",
+      "date": "2020-03-20T16:30:00Z"
     },
     {
-      "date": "03/23/2020",
-      "url": "https://sf.gov/news/getting-online-time-coronavirus-covid-19-outbreak",
-      "text": "City’s Digital Equity Initiative provides a list of resources for accessing the Internet at a crucial time."
+      "url": "https://sf.gov/news/changes-when-applying-sf-affordable-housing-due-covid-19",
+      "text": "Changes when applying for SF affordable housing due to COVID-19",
+      "date": "2020-03-18T20:29:29Z"
+    },
+    {
+      "url": "https://sf.gov/news/trans-care-during-covid-19",
+      "text": "Trans care during COVID-19",
+      "date": "2020-03-14T01:20:04Z"
+    },
+    {
+      "url": "https://sf.gov/news/san-francisco-responds-coronavirus-limiting-gatherings-and-expanding-resources",
+      "text": "San Francisco responds to coronavirus by limiting gatherings and expanding resources",
+      "date": "2020-03-12T17:00:00Z"
+    },
+    {
+      "url": "https://sf.gov/news/san-francisco-prepares-possible-coronavirus-outbreak",
+      "text": "San Francisco prepares for possible coronavirus outbreak",
+      "date": "2020-03-09T00:00:51Z"
     }
   ]
 }

--- a/utils/formatDate.ts
+++ b/utils/formatDate.ts
@@ -7,3 +7,7 @@ export const convertDatetimeToISO8601Format = (dateString: string): string => {
 export const convertDateToISO8601Format = (dateString: string): string => {
   return dayjs(dateString).format('YYYY-MM-DD')
 }
+
+export const convertISO8601ToHumanDateFormat = (dateString: string): string => {
+  return dayjs(dateString).format('MM/DD/YYYY')
+}


### PR DESCRIPTION
@kengoy I’m posting this as a PR since it includes tweaks to the UI in order to display the new ISO 8601 dates more nicely. For future updates that just change the `news.json` file, I’ll just push directly to master, if that’s ok.

This adds new news, but also updates the UI to format things more nicely, since the dates in the data are now in ISO 8601 format. I formatted things as just dates (e.g. `04/14/2020`) since the date column is pretty narrow. We do have full datetimes now, though, so we could tweak this to display `04/14/2020 3:15 pm`, for example. Let me know if I should change that.

The actual scraper script is in the data repo (github.com/sfbrigade/data-covid19-sfbayarea/). Using updating the `news.json` file is basically just:

```sh
$ python scraper_news.py > path/to/this/repo/data/news.json
```