### PR TITLE
Stop erroring when there's no new news

### DIFF
--- a/.github/workflows/news_update.yml
+++ b/.github/workflows/news_update.yml
@@ -33,20 +33,40 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: '3.x'
-
-    # Runs a set of commands using the runners shell
-    - name: Run a multi-line script
+    
+    - name: Install Data Scraper & Dependencies
       run: |
-        echo This is to update data/data.json automatically every day.
-        git config user.name ${{ secrets.githubaction_config_user_name }}
-        git config user.email ${{ secrets.githubaction_config_user_email }}
         git clone https://github.com/sfbrigade/data-covid19-sfbayarea.git
         cd data-covid19-sfbayarea
         python -m pip install --upgrade pip
         pip install -r requirements.txt;
+        
+        # Keep track of the version used so we can use it in commit messages
+        echo "::set-env name=SCRAPER_COMMIT::$(git rev-parse HEAD)"
+
+
+    - name: Scrape News
+      run: |
+        cd data-covid-19-sfbayarea
         python scraper_news.py --format json_simple > ../data/news.json
-        cd ..
-        git add data/news.json
-        git commit -m "GitHubAction: news data update."
-        git push
-        echo If a new commit exists, please create a Pull Request from github-action branch.
+    
+    - name: Commit Changes
+      run: |
+        if [ -z "$(git status --porcelain)" ] then
+          echo 'Nothing to commit!'
+        else
+          # Configure git
+          git config user.name ${{ secrets.githubaction_config_user_name }}
+          git config user.email ${{ secrets.githubaction_config_user_email }}
+
+          echo 'Committing updated news data...'
+          git add data/news.json
+          git commit -m "GitHubAction: news data update.
+
+          Created with commit ${SCRAPER_COMMIT} from sfbrigade/data-covid19-sfbayarea
+          https://github.com/sfbrigade/data-covid19-sfbayarea/commit/${SCRAPER_COMMIT}
+          "
+          git push
+          echo "Committed: $(git show HEAD --no-patch --format=reference)"
+          echo 'You should make a pull request to put these changes on master!'
+        fi


### PR DESCRIPTION
The news scraper fails when there's no new news from the scraper:

<img width="575" alt="Screen Shot 2020-05-15 at 2 52 36 PM" src="https://user-images.githubusercontent.com/74178/82099261-c36d6a80-96bb-11ea-9b80-95b9549bfd81.png">

Since we expect that to be common, these failures can be confusing and, even worse, can mask more meaningful failures that need to be fixed. Instead, check for whether there was new news and only try to commit if so — that way we don't cause errors if there's nothing new.

This also breaks up the workflow into more granular steps, so it's easier to see where exactly something is going wrong.

Finally, it changes the commit message to include information about what commit of sfbrigade/data-covid19-sfbayarea was used to produce the data.

@kengoy I asked over on #134 whether we really need a PR for the results of this workflow.
- **If not,** I’ll change this to checkout and commit on `master` instead of the `github-action` branch.
- **If you still want a PR,** I think we should have the workflow automatically create it if there were changes. There’s a nice action someone else made for this called [“create-pull-request”](https://github.com/peter-evans/create-pull-request) that can do most of the work. We should use a different branch from the data update workflow so they can have separate PRs.

Let me know about the above and I’ll do whichever makes the most sense.

Finally, we could make similar changes to the data update workflow, but I didn’t do so in order to avoid conflicting with #124.