### PR TITLE
Automatically create PRs for new scraper data/news

### DIFF
--- a/.github/workflows/data_update.yml
+++ b/.github/workflows/data_update.yml
@@ -15,19 +15,16 @@ jobs:
     - name: Checkout Main repo
       uses: actions/checkout@v2
       with:
-        key: ${{ secrets.data_daily_update }}
         ssh-key: ${{ secrets.data_daily_update }}
-        ref: github-action
-        path: stop-covid19-sfbayarea
+        path: site
 
     # Checkout data scraper repo
     - name: Checkout Data Scraper
       uses: actions/checkout@v2
       with:
-        key: ${{ secrets.data_daily_update }}
         ssh-key: ${{ secrets.data_daily_update }}
         repository: sfbrigade/data-covid19-sfbayarea
-        path: data-covid19-sfbayarea
+        path: scraper
 
     # The scraper uses Python 3.7+, so make sure we've got the latest 3.x
     - name: Set up Python 3.x
@@ -35,19 +32,41 @@ jobs:
       with:
         python-version: '3.x'
 
-    - name: Install Data Scraper & Dependencies, and Run the scraper
+    # Install dependencis
+    # - The commit that was checked out will be available as $SCRAPER_COMMIT.
+    - name: Install Data Scraper & Dependencies
       run: |
-        cd ${GITHUB_WORKSPACE}/data-covid19-sfbayarea
+        cd ${GITHUB_WORKSPACE}/scraper
         python -m pip install --upgrade pip
         pip install -r requirements.txt;
-        python scraper.py > ${GITHUB_WORKSPACE}/stop-covid19-sfbayarea/data/data.json
 
-    - name: Commit Changes
+        # Keep track of the version used so we can use it in commit messages
+        echo "::set-env name=SCRAPER_COMMIT::$(git rev-parse HEAD)"
+
+    - name: Scrape Data
       run: |
-        cd ${GITHUB_WORKSPACE}/stop-covid19-sfbayarea
-        git config user.name ${{ secrets.githubaction_config_user_name }}
-        git config user.email ${{ secrets.githubaction_config_user_email }}
-        git add data/data.json
-        git commit -m "GitHubAction: Daily data update."
-        git push
-        echo Git commit and push completed for the daily data update. Please create a Pull Request from github-action branch.
+        cd ${GITHUB_WORKSPACE}/scraper
+        python scraper.py > ${GITHUB_WORKSPACE}/site/data/data.json
+
+    - name: Create PR if New Data
+      uses: peter-evans/create-pull-request@v2
+      with:
+        path: site
+        # If this branch already exists, it will be replaced with a commit
+        # based on the changes from this job. If there's already a PR for it,
+        # the PR will be updated. The end result is that each run of this job
+        # supersedes or replaces any previous runs that haven't been reviewed
+        # and merged yet.
+        branch: auto-update-data
+        title: 'GitHub action: data update'
+        body: |
+          Created using commit [${{env.SCRAPER_COMMIT}}](https://github.com/sfbrigade/data-covid19-sfbayarea/commit/${{env.SCRAPER_COMMIT}})
+          from sfbrigade/data-covid19-sfbayarea.
+          
+          Scraped at: ${{ env.SCRAPER_TIME }}
+        commit-message: |
+          GitHubAction: data update
+          
+          Created with commit ${{env.SCRAPER_COMMIT}} from sfbrigade/data-covid19-sfbayarea
+          https://github.com/sfbrigade/data-covid19-sfbayarea/commit/${{env.SCRAPER_COMMIT}}
+        reviewers: kengoy

--- a/.github/workflows/data_update.yml
+++ b/.github/workflows/data_update.yml
@@ -45,6 +45,7 @@ jobs:
 
     - name: Scrape Data
       run: |
+        echo "::set-env name=SCRAPER_TIME::$(date)"
         cd ${GITHUB_WORKSPACE}/scraper
         python scraper.py > ${GITHUB_WORKSPACE}/site/data/data.json
 

--- a/.github/workflows/news_update.yml
+++ b/.github/workflows/news_update.yml
@@ -13,16 +13,13 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
-        key: ${{ secrets.data_daily_update }}
         ssh-key: ${{ secrets.data_daily_update }}
-        ref: github-action
         path: site
 
     # Checkout news scraper repo
     - name: Checkout Data Scraper
       uses: actions/checkout@v2
       with:
-        key: ${{ secrets.data_daily_update }}
         ssh-key: ${{ secrets.data_daily_update }}
         repository: sfbrigade/data-covid19-sfbayarea
         path: scraper
@@ -50,25 +47,25 @@ jobs:
         cd ${GITHUB_WORKSPACE}/scraper
         python scraper_news.py --format json_simple > "${GITHUB_WORKSPACE}/site/data/news.json"
     
-    # Check if we have news update, then commit
-    - name: Commit Changes
-      run: |
-        cd ${GITHUB_WORKSPACE}/site
-        if [[ "$(git status --porcelain)" =~ 'data/' ]]; then
-          # Configure git
-          git config user.name ${{ secrets.githubaction_config_user_name }}
-          git config user.email ${{ secrets.githubaction_config_user_email }}
-
-          echo 'Committing updated news data...'
-          git add data/
-          git commit -m "GitHubAction: news data update.
-
-          Created with commit ${SCRAPER_COMMIT} from sfbrigade/data-covid19-sfbayarea
-          https://github.com/sfbrigade/data-covid19-sfbayarea/commit/${SCRAPER_COMMIT}
-          "
-          git push
-          echo "Committed: $(git show HEAD --no-patch --format=reference)"
-          echo 'You should make a pull request to put these changes on master!'
-        else
-          echo 'Nothing to commit!'
-        fi
+    - name: Create PR if New Data
+      uses: peter-evans/create-pull-request@v2
+      with:
+        path: site
+        # If this branch already exists, it will be replaced with a commit
+        # based on the changes from this job. If there's already a PR for it,
+        # the PR will be updated. The end result is that each run of this job
+        # supersedes or replaces any previous runs that haven't been reviewed
+        # and merged yet.
+        branch: auto-update-news
+        title: 'GitHub action: news update'
+        body: |
+          Created using commit [${{env.SCRAPER_COMMIT}}](https://github.com/sfbrigade/data-covid19-sfbayarea/commit/${{env.SCRAPER_COMMIT}})
+          from sfbrigade/data-covid19-sfbayarea.
+          
+          Scraped at: ${{ env.SCRAPER_TIME }}
+        commit-message: |
+          GitHubAction: news update
+          
+          Created with commit ${{env.SCRAPER_COMMIT}} from sfbrigade/data-covid19-sfbayarea
+          https://github.com/sfbrigade/data-covid19-sfbayarea/commit/${{env.SCRAPER_COMMIT}}
+        reviewers: kengoy, Mr0grog

--- a/.github/workflows/news_update.yml
+++ b/.github/workflows/news_update.yml
@@ -44,6 +44,7 @@ jobs:
     # Run the news scraper
     - name: Scrape News
       run: |
+        echo "::set-env name=SCRAPER_TIME::$(date)"
         cd ${GITHUB_WORKSPACE}/scraper
         python scraper_news.py --format json_simple > "${GITHUB_WORKSPACE}/site/data/news.json"
     


### PR DESCRIPTION
Instead of committing new data to a branch that someone has to manually check, our data/news update workflows now automatically create pull requests when there is new data. If the job runs again before the previous pull request is merged, it effectively replaces the branch (and updates the pull request) with a new one based directly off master.

This also puts data and news updates on different branches (up until now, they've been combined). Doing so should make it easier to manage their updates, since they come at different times and schedules.