### PR TITLE
Feature/issue106

### DIFF
--- a/components/CasesSummary.vue
+++ b/components/CasesSummary.vue
@@ -66,12 +66,14 @@
 <style lang="scss" scoped>
 .summary {
   text-align: center;
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  & > div {
-    border-right: 2px solid lightgray;
-    &:last-child {
-      border-right: none;
+  @media screen and (min-width: 640px) {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    & > div {
+      border-right: 2px solid lightgray;
+      &:last-child {
+        border-right: none;
+      }
     }
   }
   .stat-title {
@@ -81,8 +83,12 @@
     line-height: 22px;
   }
   .stat-number {
-    padding: 10px;
-    margin: 20px 0px;
+    @media screen and (min-width: 640px) {
+      padding: 30px;
+    }
+    @media screen and (max-width: 640px) {
+      padding: 15px;
+    }
     color: black;
     font-weight: bold;
     line-height: 39px;
@@ -94,6 +100,11 @@
     font-size: 14px;
     line-height: 19px;
     color: #333333;
+  }
+  @media screen and (max-width: 640px) {
+    .case-frequency {
+      padding: 50px;
+    }
   }
 }
 @media screen and (min-width: 640px) {

--- a/components/DataView.vue
+++ b/components/DataView.vue
@@ -95,7 +95,7 @@ export default class DataView extends Vue {
     @include card-h2();
   }
   &-ToolbarTitle {
-    font-size: 24px;
+    font-size: 20px;
     font-weight: bold;
     line-height: 1.5;
   }
@@ -105,7 +105,7 @@ export default class DataView extends Vue {
   }
   &-CardTextForXS {
     margin-bottom: 46px;
-    margin-top: 70px;
+    margin-top: 30px;
   }
   &-Footer {
     background-color: $white-1 !important;

--- a/components/Stats.vue
+++ b/components/Stats.vue
@@ -32,7 +32,7 @@
         <DataView>
           <div class="county-select-container">
             <div class="county-select">
-              <label>Show Data For:</label>
+              <label class="selection">Show Data For:</label>
               <select v-model="currentCounty" class="select-css">
                 <option v-for="(countyName, index) in countyNames" :key="index">
                   {{ countyName }}
@@ -226,6 +226,36 @@ export default {
         align-items: center;
       }
     }
+    @include lessThan($small) {
+      .county-select-container {
+        display: initial;
+        grid-template-columns: initial;
+        .county-stats {
+          display: initial;
+          grid-template-columns: initial;
+          .stat-title {
+            margin-top: 50px;
+          }
+          .stat-number {
+            padding: 10px;
+            margin: 20px 0px;
+            font-size: 36px;
+          }
+          .stat-note {
+          }
+          .border {
+            border-right: initial;
+            margin-bottom: 30px;
+          }
+        }
+        .county-select {
+          display: grid;
+        }
+        .selection {
+          text-align: center;
+        }
+      }
+    }
   }
 
   .select-css {
@@ -266,6 +296,15 @@ export default {
     }
     option {
       font-weight: normal;
+    }
+  }
+  @include lessThan($small) {
+    .select-css {
+      width: initial;
+      max-width: initial;
+      margin-top: 20px;
+      margin-bottom: 40px;
+      align-items: center;
     }
   }
 }

--- a/components/TimeBarChart.vue
+++ b/components/TimeBarChart.vue
@@ -210,8 +210,8 @@ export default {
                 display: false
               },
               ticks: {
-                fontSize: 9,
-                maxTicksLimit: 30,
+                fontSize: 12,
+                maxTicksLimit: 20,
                 fontColor: '#808080',
                 maxRotation: 0,
                 minRotation: 0,
@@ -230,7 +230,7 @@ export default {
                 tickMarkLength: 10
               },
               ticks: {
-                fontSize: 11,
+                fontSize: 12,
                 fontColor: '#808080',
                 padding: 3,
                 fontStyle: 'bold',


### PR DESCRIPTION
Adjusted layout for mobile. (#106) @thuongho @shaoevans  Pls review this PR.

FYI: UI Wireframe https://www.figma.com/file/iUS5LdAnuTKVei88QwPPCH/Bay-Area-Pandemic-Dashboard-(PanDa)-by-Bay-Area-Brigades?node-id=1286%3A5448


Screenshots after the adjustment.

<img width="486" alt="Screen Shot 2020-06-23 at 12 49 21 AM" src="https://user-images.githubusercontent.com/61864097/85375727-92b6f700-b4eb-11ea-8f9d-5b50ea9099bd.png">

<img width="490" alt="Screen Shot 2020-06-23 at 12 49 28 AM" src="https://user-images.githubusercontent.com/61864097/85375721-9185ca00-b4eb-11ea-972a-6220a8b7e8f0.png">

<img width="485" alt="Screen Shot 2020-06-23 at 12 49 34 AM" src="https://user-images.githubusercontent.com/61864097/85375715-8fbc0680-b4eb-11ea-88aa-6c297237a311.png">
