### PR TITLE
Add GitHub action for new data scrapers

### DIFF
--- a/.github/workflows/data_update_v2.yml
+++ b/.github/workflows/data_update_v2.yml
@@ -1,0 +1,73 @@
+name: data.v2.json update
+
+on:
+  schedule:
+    # Run at 3 AM PDT every day
+    - cron: 0 10 * * *
+
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    # Checkout the main repo
+    - name: Checkout Main repo
+      uses: actions/checkout@v2
+      with:
+        ssh-key: ${{ secrets.data_daily_update }}
+        path: site
+
+    # Checkout data scraper repo
+    - name: Checkout Data Scraper
+      uses: actions/checkout@v2
+      with:
+        ssh-key: ${{ secrets.data_daily_update }}
+        repository: sfbrigade/data-covid19-sfbayarea
+        path: scraper
+
+    # The scraper uses Python 3.7+, so make sure we've got the latest 3.x
+    - name: Set up Python 3.x
+      uses: actions/setup-python@v1
+      with:
+        python-version: '3.x'
+
+    # Install dependencis
+    # - The commit that was checked out will be available as $SCRAPER_COMMIT.
+    - name: Install Data Scraper & Dependencies
+      run: |
+        cd ${GITHUB_WORKSPACE}/scraper
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt;
+
+        # Keep track of the version used so we can use it in commit messages
+        echo "::set-env name=SCRAPER_COMMIT::$(git rev-parse HEAD)"
+
+    - name: Scrape Data
+      run: |
+        echo "::set-env name=SCRAPER_TIME::$(date)"
+        cd ${GITHUB_WORKSPACE}/scraper
+        python scraper_data.py > "${GITHUB_WORKSPACE}/site/data/data.v2.json"
+
+    - name: Create PR if New Data
+      uses: peter-evans/create-pull-request@v2
+      with:
+        path: site
+        # If this branch already exists, it will be replaced with a commit
+        # based on the changes from this job. If there's already a PR for it,
+        # the PR will be updated. The end result is that each run of this job
+        # supersedes or replaces any previous runs that haven't been reviewed
+        # and merged yet.
+        branch: auto-update-data
+        title: 'GitHub action: data update'
+        body: |
+          Created using commit [${{env.SCRAPER_COMMIT}}](https://github.com/sfbrigade/data-covid19-sfbayarea/commit/${{env.SCRAPER_COMMIT}})
+          from sfbrigade/data-covid19-sfbayarea.
+          
+          Scraped at: ${{ env.SCRAPER_TIME }}
+        commit-message: |
+          GitHubAction: data update
+          
+          Created with commit ${{env.SCRAPER_COMMIT}} from sfbrigade/data-covid19-sfbayarea
+          https://github.com/sfbrigade/data-covid19-sfbayarea/commit/${{env.SCRAPER_COMMIT}}
+        reviewers: kengoy

--- a/.github/workflows/data_update_v2.yml
+++ b/.github/workflows/data_update_v2.yml
@@ -58,15 +58,15 @@ jobs:
         # the PR will be updated. The end result is that each run of this job
         # supersedes or replaces any previous runs that haven't been reviewed
         # and merged yet.
-        branch: auto-update-data
-        title: 'GitHub action: data update'
+        branch: auto-update-data-v2
+        title: 'GitHub action: data v2 update'
         body: |
           Created using commit [${{env.SCRAPER_COMMIT}}](https://github.com/sfbrigade/data-covid19-sfbayarea/commit/${{env.SCRAPER_COMMIT}})
           from sfbrigade/data-covid19-sfbayarea.
           
           Scraped at: ${{ env.SCRAPER_TIME }}
         commit-message: |
-          GitHubAction: data update
+          GitHubAction: data v2 update
           
           Created with commit ${{env.SCRAPER_COMMIT}} from sfbrigade/data-covid19-sfbayarea
           https://github.com/sfbrigade/data-covid19-sfbayarea/commit/${{env.SCRAPER_COMMIT}}


### PR DESCRIPTION
Because the new scrapers aren't yet our primary source, this is a separate workflow from the normal data workflow, and the output goes into `data/data.v2.json` so it doesn't overwrite the production data the site currently relies on.

@kengoy does the file name here seem good to you?

Sorry this took a bit — I originally thought one of the new scrapers was still failing, and wrote a really complex version that ran each county scraper independently and merged them together. It turns out that wasn’t needed, though, so I simplified it to being almost exactly the same as the current scraper, with only a slightly different command.