### PR TITLE
Cache dependencies for data/news updates

### DIFF
--- a/.github/workflows/data_update.yml
+++ b/.github/workflows/data_update.yml
@@ -32,6 +32,18 @@ jobs:
       with:
         python-version: '3.x'
 
+    - name: Cache Python Dependencies
+      uses: actions/cache@v2
+      with:
+        path: ~/.cache/pip
+        # NOTE: we can hash these requirements files together, but keeping them
+        # separate allows us to load a partial cache if only the dev
+        # requirements have changed.
+        key: ${{ runner.os }}-pip-${{ hashFiles('scraper/requirements.txt') }}-${{ hashFiles('scraper/requirements-dev.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-${{ hashFiles('scraper/requirements.txt') }}-
+          ${{ runner.os }}-pip-
+
     # Install dependencis
     # - The commit that was checked out will be available as $SCRAPER_COMMIT.
     - name: Install Data Scraper & Dependencies

--- a/.github/workflows/data_update_v2.yml
+++ b/.github/workflows/data_update_v2.yml
@@ -32,6 +32,18 @@ jobs:
       with:
         python-version: '3.x'
 
+    - name: Cache Python Dependencies
+      uses: actions/cache@v2
+      with:
+        path: ~/.cache/pip
+        # NOTE: we can hash these requirements files together, but keeping them
+        # separate allows us to load a partial cache if only the dev
+        # requirements have changed.
+        key: ${{ runner.os }}-pip-${{ hashFiles('scraper/requirements.txt') }}-${{ hashFiles('scraper/requirements-dev.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-${{ hashFiles('scraper/requirements.txt') }}-
+          ${{ runner.os }}-pip-
+
     # Install dependencis
     # - The commit that was checked out will be available as $SCRAPER_COMMIT.
     - name: Install Data Scraper & Dependencies

--- a/.github/workflows/news_update.yml
+++ b/.github/workflows/news_update.yml
@@ -30,6 +30,18 @@ jobs:
       with:
         python-version: '3.x'
 
+    - name: Cache Python Dependencies
+      uses: actions/cache@v2
+      with:
+        path: ~/.cache/pip
+        # NOTE: we can hash these requirements files together, but keeping them
+        # separate allows us to load a partial cache if only the dev
+        # requirements have changed.
+        key: ${{ runner.os }}-pip-${{ hashFiles('scraper/requirements.txt') }}-${{ hashFiles('scraper/requirements-dev.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-${{ hashFiles('scraper/requirements.txt') }}-
+          ${{ runner.os }}-pip-
+
     # Install dependencis
     # - The commit that was checked out will be available as $SCRAPER_COMMIT.
     - name: Install Data Scraper & Dependencies


### PR DESCRIPTION
When running our data and news update workflows, we were downloading fresh copies of our dependencies from PyPI every time. That's not so great for a variety of reasons:
- It costs PyPI money for the bandwidth, which is paid for with donations;
- It's a little slower to load the data over the internet instead of a nearby cache.

This adds a cache for the Python dependencies that are installed via Pip.