### PR TITLE
Add San Francisco County page info to info.json #236

### DIFF
--- a/data/info.json
+++ b/data/info.json
@@ -1,0 +1,194 @@
+{
+  "San Francisco County": {
+    "info": [
+      {
+        "header": "County Guidelines",
+        "body": [
+          {
+            "h4": "Shelter in Place",
+            "content": [
+              {
+                "p2": [
+                  {
+                    "p": "Residents should remain at home when possible as it is the safest choice. If you do leave your home, keep the following guidelines in mind."
+                  }
+                ],
+                "bullets": [
+                  {
+                    "bullet": "Maintain 6ft distance between yourself and people who are not in your hosehold unit."
+                  },
+                  {
+                    "bullet": "Wear a mask, scarf, bandana or other facial covering."
+                  },
+                  {
+                    "bullet": "Limit face to face interactions with those vulnerable to the coronavirus such as those over 60 or those with underlying health conditions."
+                  },
+                  {
+                    "bullet": "Wash hands frequently with soap and water for at least 20 seconds, or use hand sanitizer."
+                  },
+                  {
+                    "bullet": "Cover coughs and sneezes with a tissue or fabric or, if not possible, use the sleeve of your shirt or elbow. Do not cough or sneeze into your hand."
+                  },
+                  {
+                    "bullet": "Use antibactiral wipes to clean any surface that you have to touch."
+                  }
+                ],
+                "link": "https://sf.gov/stay-home-except-essential-needs"
+              }
+            ]
+          },
+          {
+            "h4": "Hand Washing Stations",
+            "content": [
+              {
+                "p2": [
+                  {
+                    "p": "A map of 'pit stops' and public hand washing stations in San Francisco is available at the link below."
+                  }
+                ],
+                "link": "https://www.google.com/maps/d/u/0/viewer?mid=1jCE9lI8Iv12tO-wWrF6RIQPWKXGBK0_z&ll=37.77885554963088%2C-122.45262763559288&z=11"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "header": "Testing",
+        "body": [
+          {
+            "content": [
+              {
+                "p2": [
+                  {
+                    "p": "Multple sites across the city are now offering COVID-19 diagnostic testing. Consult the detailed map resource published by the team at DataSF."
+                  }
+                ],
+                "link": "https://datasf.org/covid19-testing-locations/"
+              }
+            ]
+          },
+          {
+            "content": [
+              {
+                "p2": [
+                  {
+                    "p": "Testing is available for any California resident who has one or more syptoms of the virus or who has been in contact with someone who has the virus within the past 14 days."
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "h4": "Insurance",
+            "content": [
+              {
+                "p2": [
+                  {
+                    "p": "If you have health insurance, schedule a consultation or test through your healthcare proider."
+                  },
+                  {
+                    "p": "If you are uninsured, there are multiple test sites within the city where you can still be tested. The DataSF map provides a filter to help you find an elligible site."
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "header": "Transportation",
+        "body": [
+          {
+            "h4": "MUNI"
+          },
+          {
+            "h4": "Status of Routes",
+            "content": [
+              {
+                "p2": [
+                  {
+                    "p": "All Muni Metro/light rail has been replaced by buses and only certain core routes remain open. Downtown Metro stations remain open to accomodate BART riders. Rapid bus lines are temporarily suspended, but many late night Owl services remain. Refer to MUNIs Core Service Plan to see details of route adjusmtents and closures."
+                  }
+                ],
+                "link": "https://www.sfmta.com/travel-updates/covid-19-muni-core-service-plan"
+              }
+            ]
+          },
+          {
+            "h4": "Rider Guidelines",
+            "content": [
+              {
+                "p2": [
+                  {
+                    "p": "Masks or face coverings are required for all MUNI riders. Backdoor boarding is now required on all buses except for passengers with wheelchairs or other accesibility needs. Muni provides updates at the link below."
+                  }
+                ],
+                "link": "https://www.sfmta.com/projects/covid-19-developments-response"
+              }
+            ]
+          },
+          {
+            "h4": "Rider Assistance",
+            "content": [
+              {
+                "p2": [
+                  {
+                    "p": "Paratransit continues to be available for riders with disabilities. Paratransit riders are also required to wear masks or face coverings while using the service."
+                  },
+                  {
+                    "p": "Passengers over 65 or with disabilities may also be elligible for an essential trip card. This card provides a limited number of discounted taxi rides each month for essential trips."
+                  }
+                ],
+                "link": "https://www.sfmta.com/getting-around/accessibility/paratransit/essential-trip-card"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "header": "Local Businesses",
+        "body": [
+          {
+            "h4": "Restaurants & Food Service",
+            "content": [
+              {
+                "p2": [
+                  {
+                    "p": "There are still over one-thousand restaurants open for takeout or delivery in San Francisco. Eater San Francisco maintains a list of open restaurants here."
+                  }
+                ],
+                "link": "https://sf.eater.com/2020/3/17/21184129/san-francisco-takeout-delivery-coronavirus"
+              },
+              {
+                "p2": [
+                  {
+                    "p": "For recommendations and curated lists, check out their guide to Bay Area eating during the pandemic."
+                  }
+                ],
+                "link": "https://sf.eater.com/2020/4/8/21212947/san-francisco-what-to-eat-delivery-takeout-groceries-coronavirus-covid-19-shutdown"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "header": "Recreation",
+        "body": [
+          {
+            "h4": "Public Spaces",
+            "content": [
+              {
+                "p2": [
+                  {
+                    "p": "Public recreation spaces have begun to reopen since early June. Dog parks, tennis courts and parking lots have reopened. Playgrounds, basketball courts, outdoor gyms and other public facilities remain closed. Masks and maintaining physical distancing are required at re-opened facilities."
+                  }
+                ],
+                "link": "https://sfrecpark.org/AlertCenter.aspx"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
I started a template for the info page using San Francisco for data. Basically I copied over the categories from the [Covid 19 Research Google Sheet](https://docs.google.com/spreadsheets/d/1_wBXS62S5oBQrwetGc8_-dFvDjEmNqzqHwUeP-DzkYs/edit#gid=974216782) to the info.json. 

Take a look at the json and let me know if it makes sense. Each county's info is divided into 
```
header
body
  h4
  content
    p2s
      p2
    bullets
    link
```
so that it can easily be parsed and converted to HTML DOM elements that @nikobooth already had defined. 

Oh and there are some p3 tags on the google sheet in which I just changed them to p2 to keep it consistent. I only saw P3 on SF and none of the other counties that I quickly glanced at.