### PR TITLE
Run v2 county scrapers independently

### DIFF
--- a/.github/workflows/data_update_v2.yml
+++ b/.github/workflows/data_update_v2.yml
@@ -59,7 +59,22 @@ jobs:
       run: |
         echo "::set-env name=SCRAPER_TIME::$(date)"
         cd ${GITHUB_WORKSPACE}/scraper
-        python scraper_data.py > "${GITHUB_WORKSPACE}/site/data/data.v2.json"
+        OUT_PATH="${GITHUB_WORKSPACE}/site/data/data.v2.json"
+        
+        # Ideally, we'd just run the scraper against all counties like below:
+        #     python scraper_data.py > "${OUT_PATH}"
+        # But we don't want to stop if there are errors, so instead we run each
+        # scraper individually. Then we combine all the outputs and overlay
+        # them on top of the previoius output.
+        (python scraper_data.py alameda || echo '{}') > alameda.json
+        (python scraper_data.py san_francisco || echo '{}') > san_francisco.json
+        (python scraper_data.py solano || echo '{}') > solano.json
+        (python scraper_data.py sonoma || echo '{}') > sonoma.json
+        # Combine outputs with the previous run's saved output:
+        jq -s \
+          '.[0] + .[1] + .[2] + .[3] + .[4]' \
+          "${OUT_PATH}" alameda.json san_francisco.json solano.json sonoma.json \
+          > "${OUT_PATH}"
 
     - name: Create PR if New Data
       uses: peter-evans/create-pull-request@v2


### PR DESCRIPTION
Instead of scraping all the counties at once when creating the `data.v2.json` file, scrape each one independently. That way, if one county has errors, it doesn't prevent other counties from getting updated.

Ideally, we can incorporate this behavior directly into the data side, but PRs are pretty slow to merge there and the implementation might be a bit more complicated.

The basic approach here is to run each county as a separate process, outputting all the results into separate JSON files. Then we use `jq` to overlay the old data + the files with the new output for each county. If a county fails, we ensure its JSON file is just an empty object (`{}`) so it doesn't overwrite the old data for that county.