### PR TITLE
Create PR on partial news scraper failures

### DIFF
--- a/.github/workflows/news_update.yml
+++ b/.github/workflows/news_update.yml
@@ -55,14 +55,15 @@ jobs:
 
     # Run the news scraper
     - name: Scrape News
+      id: scrape_news
+      # The scraper may error on some counties but succeed on others. We want to
+      # continue so that we still generate PRs for partial successes. We'll handle
+      # failures in a later step.
+      continue-on-error: true
       run: |
         echo "::set-env name=SCRAPER_TIME::$(date)"
         cd ${GITHUB_WORKSPACE}/scraper
-        # TODO: stop explicitly listing every county when the scraper repo is
-        # updated to scrape every county by default. (We have to do this first
-        # before the scraper can update, otherwise it would break older code in
-        # this repo!)
-        python scraper_news.py alameda contra_costa marin napa san_francisco san_mateo santa_clara solano sonoma --format json_feed --format rss --output "${GITHUB_WORKSPACE}/site/data/news/"
+        python scraper_news.py --format json_feed --format rss --output "${GITHUB_WORKSPACE}/site/data/news/" 2> errors.txt
     
     - name: Create PR if New Data
       uses: peter-evans/create-pull-request@v2
@@ -86,3 +87,24 @@ jobs:
           Created with commit ${{env.SCRAPER_COMMIT}} from sfbrigade/data-covid19-sfbayarea
           https://github.com/sfbrigade/data-covid19-sfbayarea/commit/${{env.SCRAPER_COMMIT}}
         reviewers: kengoy, Mr0grog
+
+    - name: Send Errors to Slack and Fail
+      if: ${{ steps.scrape_news.outcome == "failure" }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      run: |
+        ERRORS_PATH="${GITHUB_WORKSPACE}/scraper/errors.txt"
+        
+        echo "Encountered the following errors while scraping:"
+        echo "------------------------------------------------"
+        echo `cat "${ERRORS_PATH}"`
+          
+        # The error text can contain unescaped quotes, newlines, etc.
+        # Use jq to make sure we are composing correctly formatted JSON.
+        # `--raw-input` treats the input as strings instead of JSON.
+        # `--slurp` causes all lines to be combined into one string.
+        ERRORS_JSON=`cat "${ERRORS_PATH}" | jq --slurp --raw-input '{"text": ("*News Errors:*\n" + .)}'`
+        curl -X POST -H 'Content-type: application/json' --data "${ERRORS_JSON}" $SLACK_WEBHOOK_URL
+        
+        echo "Marking workflow as failed."
+        false


### PR DESCRIPTION
It’s possible for the news scraper, like the data scraper, to succeed on some counties while failing on others. In this case, it exits with an error, but still did useful work.

Instead of stopping the workflow in its tracks, this change allows the workflow to continue so we still get a PR with updates from the successful counties.

Like the data scraper, it also sends error logs to Slack. Unlike the data scraper, it also fails the workflow show it shows up as an error in the actions panel on GitHub. If this works well (it's the first time I've used the conditional features in actions), I'll port this back over to the data scraper, too.

**NOTE: we should land this before we merge sfbrigade/data-covid19-sfbayarea#135.**