### PR TITLE
Fix quotes in news_update workflow

### DIFF
--- a/.github/workflows/news_update.yml
+++ b/.github/workflows/news_update.yml
@@ -89,7 +89,7 @@ jobs:
         reviewers: kengoy, Mr0grog
 
     - name: Send Errors to Slack and Fail
-      if: ${{ steps.scrape_news.outcome == "failure" }}
+      if: ${{ steps.scrape_news.outcome == 'failure' }}
       env:
         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
       run: |


### PR DESCRIPTION
It turns out double quotes are not valid in workflow conditions!