### PR TITLE
Fix san mateo data

### DIFF
--- a/utils/formatGraph.ts
+++ b/utils/formatGraph.ts
@@ -21,12 +21,14 @@ export default (data: DataType[]) => {
   let previousDayCases = 0
   let deathSubTotal = 0
   let deathPreviousDayCases = 0
+  let cases = 0
+  let deaths = 0
   data
     .filter(d => new Date(d.date) > lastMonth)
     .forEach((d, idx, array) => {
       const date = new Date(d.date)
-      const cases = d.cases
-      const deaths = d.deaths
+      cases = d.cases || cases
+      deaths = d.deaths || deaths
       if (!isNaN(cases)) {
         if (cases === 0) {
           return

--- a/utils/formatGraph.ts
+++ b/utils/formatGraph.ts
@@ -14,9 +14,7 @@ type GraphDataType = {
 
 export default (data: DataType[]) => {
   const graphData: GraphDataType[] = []
-  const today = new Date()
-  const lastMonth = new Date()
-  lastMonth.setMonth(today.getMonth() - 3)
+  const lastMonth = new Date('2020-01-23')
   let subTotal = 0
   let previousDayCases = 0
   let deathSubTotal = 0


### PR DESCRIPTION
For issue#764

The data in data/data.json after 9/23 looks faulty, it's consistently displaying 0 cases/deaths which is causing problems in the rendering as well. 

This can be fixed by setting and earlier start date for the graph data and forcing some behavior on cumulative cases/deaths but I don't know if that's the desired fix.

![Screenshot from 2020-12-30 22-14-43](https://user-images.githubusercontent.com/52506986/103397325-bb4c2900-4aec-11eb-8fc3-7dda001cbf68.png)
![Screenshot from 2020-12-30 22-14-56](https://user-images.githubusercontent.com/52506986/103397327-bdae8300-4aec-11eb-9fad-d013f2eac89b.png)
