### PR TITLE
Fix month labeling on x-axis

### DIFF
--- a/utils/formatCountyHospitalizationData.ts
+++ b/utils/formatCountyHospitalizationData.ts
@@ -43,7 +43,8 @@ const formatHospitalizationDataGraph = (data: HospitalizationDataType[]) => {
       const date = new Date(d.date)
 
       graphData.push({
-        label: `${date.getUTCMonth() + 1}/${date.getUTCDate()}`,
+        label: `${date.getUTCMonth() +
+          1}/${date.getUTCDate()}/${date.getUTCFullYear()}`,
         icuConfirmed:
           d.icu_covid_confirmed_patients + d.icu_suspected_covid_patients,
         icuAvailable: d.icu_available_beds

--- a/utils/formatGraph.ts
+++ b/utils/formatGraph.ts
@@ -57,7 +57,8 @@ export default (data: DataType[]) => {
         previousDayCases = cases
         deathPreviousDayCases = deaths
         graphData.push({
-          label: `${date.getUTCMonth() + 1}/${date.getUTCDate()}`,
+          label: `${date.getUTCMonth() +
+            1}/${date.getUTCDate()}/${date.getUTCFullYear()}`,
           confirmedTransition: subTotal,
           cumulative: cases,
           deathTransition: deathSubTotal,


### PR DESCRIPTION
@thuongho It looks like the graph was assuming all data was from 2001 so because we just got new data in January it was displaying Jan through Dec on the x-axis. Adding the year to the label could fix this. It looks like the same applies to the hospitalization data as well.

![Screenshot from 2021-01-04 13-30-26](https://user-images.githubusercontent.com/52506986/103581978-d7a3e900-4e91-11eb-8d18-bc3170241753.png)
![Screenshot from 2021-01-04 13-26-57](https://user-images.githubusercontent.com/52506986/103581982-d8d51600-4e91-11eb-8b26-7cd87c900442.png)
![Screenshot from 2021-01-04 13-26-32](https://user-images.githubusercontent.com/52506986/103581990-dd013380-4e91-11eb-824a-5ff6f78ec6e1.png)
![Screenshot from 2021-01-04 13-27-07](https://user-images.githubusercontent.com/52506986/103581994-de326080-4e91-11eb-80eb-5e6dfd70987e.png)
