### PR TITLE
Add side navigation to county guidlines

### DIFF
--- a/components/CountyGuidelines.vue
+++ b/components/CountyGuidelines.vue
@@ -1,44 +1,42 @@
 <template>
-  <div v-if="info[county] != null" class="CountyGuidelines">
-    <div v-for="(item, i) in info[county].info" :key="i">
-      <v-card class="guidelines">
-        <p class="Header">
-          {{ item.header }}
+  <div class="CountyGuidelines">
+    <v-card class="guidelines">
+      <p class="Header">
+        {{ item.header }}
+      </p>
+      <p v-if="item.date != null" class="time-updated">
+        Last updated {{ item.date }}
+      </p>
+      <div v-for="(body, j) in item.body" :key="`body-${j}`">
+        <p class="content-header">
+          {{ body.h4 }}
         </p>
-        <p v-if="item.date != null" class="time-updated">
-          Last updated {{ item.date }}
-        </p>
-        <div v-for="(body, j) in item.body" :key="`body-${j}`">
-          <p class="content-header">
-            {{ body.h4 }}
-          </p>
-          <div v-for="(content, k) in body.content" :key="`content-${k}`">
-            <div v-for="(p, l) in content.p2" :key="`p-${l}`" class="p2">
-              <p>{{ p.p }}</p>
-            </div>
-            <div
-              v-for="(bullet, m) in content.bullets"
-              :key="`bullet-${m}`"
-              class="bullets"
+        <div v-for="(content, k) in body.content" :key="`content-${k}`">
+          <div v-for="(p, l) in content.p2" :key="`p-${l}`" class="p2">
+            <p>{{ p.p }}</p>
+          </div>
+          <div
+            v-for="(bullet, m) in content.bullets"
+            :key="`bullet-${m}`"
+            class="bullets"
+          >
+            <ul>
+              <li>{{ bullet.bullet }}</li>
+            </ul>
+          </div>
+          <div class="link-container">
+            <a
+              :href="content.link"
+              class="links"
+              target="_blank"
+              rel="noopener"
             >
-              <ul>
-                <li>{{ bullet.bullet }}</li>
-              </ul>
-            </div>
-            <div class="link-container">
-              <a
-                :href="content.link"
-                class="links"
-                target="_blank"
-                rel="noopener"
-              >
-                {{ content.link }}
-              </a>
-            </div>
+              {{ content.link }}
+            </a>
           </div>
         </div>
-      </v-card>
-    </div>
+      </div>
+    </v-card>
   </div>
 </template>
 
@@ -48,8 +46,8 @@ import Info from '@/data/info.json'
 export default {
   name: 'CountyGuidelines',
   props: {
-    county: {
-      type: String,
+    item: {
+      type: Object,
       required: true
     }
   },

--- a/components/News.vue
+++ b/components/News.vue
@@ -10,9 +10,16 @@
         />
       </v-card>
     </div>
-
-    <whats-new class="mb-4" :feed="counties[currentCounty]" />
-    <CountyGuidelines :county="currentCounty" />
+    <SideNavigationOverview :categories="info(currentCounty)">
+      <template v-slot="{ item, i }">
+        <whats-new
+          v-if="i === 0"
+          class="mb-4"
+          :feed="counties[currentCounty]"
+        />
+        <CountyGuidelines v-else :ref="i" :item="item" />
+      </template>
+    </SideNavigationOverview>
   </div>
 </template>
 <script>
@@ -28,13 +35,16 @@ import SantaClaraNews from '@/data/news/santa_clara.json'
 import SolanoNews from '@/data/news/solano.json'
 import SonomaNews from '@/data/news/sonoma.json'
 import CountyGuidelines from '@/components/CountyGuidelines.vue'
+import SideNavigationOverview from '@/components/SideNavigationOverview.vue'
 import Data from '@/data/data.json'
+import Info from '@/data/info.json'
 
 export default {
   components: {
     DropDown,
     WhatsNew,
-    CountyGuidelines
+    CountyGuidelines,
+    SideNavigationOverview
   },
   data() {
     const currentCounty = 'San Francisco County'
@@ -60,7 +70,13 @@ export default {
   methods: {
     handleSelect(event) {
       this.currentCounty = event
-    }
+    },
+    info: currentCounty => [
+      { title: 'News & Updates' },
+      ...(Info[currentCounty]?.info.map(item =>
+        Object.assign({}, item, { title: item.header })
+      ) || [])
+    ]
   },
   head() {
     return {

--- a/components/SideNavigationOverview.vue
+++ b/components/SideNavigationOverview.vue
@@ -6,7 +6,7 @@
           v-for="(item, i) in categories"
           :key="i"
           v-ripple="false"
-          :to="`#sidenav-main-content-${i}`"
+          :href="`#${item.title}`"
           :class="{ active: activeCategory === i }"
           class="SideNavigationOverview-Container"
         >
@@ -22,6 +22,7 @@
     </div>
     <!-- Add Scroll Area if SideNavigationOverview is shown -->
     <div
+      ref="contentArea"
       :class="{ 'SideNav-MainContent-Scroll-Area': !isSmallScreenWidth }"
       @scroll.passive="debounce"
     >
@@ -38,7 +39,7 @@
         </div>
         <div
           v-for="(item, i) in categories"
-          :id="`sidenav-main-content-${i}`"
+          ref="mainContents"
           :key="i"
           class="SideNav-MainContent-Wrapper"
         >
@@ -78,29 +79,37 @@ export default {
       isSmallScreenWidth: false
     }
   },
+  watch: {
+    categories() {
+      this.$nextTick(() => this.scrollToCategory(0))
+    }
+  },
   mounted() {
-    // Get all FAQ category's top position to track SideNavigationOverview scroll behavior
-    const mainCategoriesCount = this.categories.length
-    const { allScrollTops, lastMainContent } = this.getAllScrollTop(
-      mainCategoriesCount
-    )
-
-    this.allScrollTops = allScrollTops
-    // last content top and height
-    this.lastMainContent = lastMainContent
-
-    // Set scroll length for the current browser size
-    this.scrollLength = this.getScrollLength()
+    this.updateScrollLengths()
     // Small screen based on SideNavigationOverview display
     this.isSmallScreenWidth = !this.sideNavigationOverviewIsShown()
     this.isPinnedSlotShown()
     if (this.isPinnedSlotShown()) this.activeCategory = null
   },
   methods: {
+    updateScrollLengths() {
+      // Get all FAQ category's top position to track SideNavigationOverview scroll behavior
+      const mainCategoriesCount = this.categories.length
+      const { allScrollTops, lastMainContent } = this.getAllScrollTop(
+        mainCategoriesCount
+      )
+      this.allScrollTops = allScrollTops
+      // last content top and height
+      this.lastMainContent = lastMainContent
+
+      // Set scroll length for the current browser size
+      this.scrollLength = this.getScrollLength()
+    },
     // Clicked function that scrolls to the anchor hash
     scrollToCategory(category) {
       this.activeCategory = category
-      location.hash = `#sidenav-main-content-${category}`
+      this.updateScrollLengths()
+      this.$refs.contentArea.scroll(0, this.allScrollTops[category])
     },
     // Debounce and handleScroll method handles when the content is scrolled
     // and 300ms after the scrolling stopped,
@@ -132,15 +141,14 @@ export default {
           document.location.hash = ''
         }
 
-        // Add title bar 340 + 30 margin + 60 nav bar
-        const NAV_AND_TITLE_BAR = 340 + 30 + 60
+        this.updateScrollLengths()
         const currentScrollTop = event.target.scrollTop
 
         // Set active for item in SideNavigationOverview that matches the current FAQ item
         if (this.isPinnedSlotShown() && currentScrollTop === 0) {
           this.activeCategory = null
         } else {
-          const currentScrollPosition = currentScrollTop + NAV_AND_TITLE_BAR
+          const currentScrollPosition = currentScrollTop
           this.activeCategory = findHashIndexBaseOnScrollPosition(
             currentScrollPosition,
             this.allScrollTops
@@ -154,13 +162,15 @@ export default {
     getAllScrollTop(mainCategoriesCount) {
       const allScrollTops = []
       const lastMainContent = {}
+      const MARGIN = 20
+      let top = -MARGIN
       for (let i = 0; i < mainCategoriesCount; i++) {
-        const elem = document.getElementById(`sidenav-main-content-${i}`)
-        const top = elem.offsetTop
+        const offsetHeight = this.$refs.mainContents[i]?.offsetHeight || 0
         allScrollTops.push(top)
+        top += offsetHeight + MARGIN
         if (i === mainCategoriesCount - 1) {
           lastMainContent.top = top
-          lastMainContent.height = elem.offsetHeight
+          lastMainContent.height = offsetHeight
         }
       }
       return { allScrollTops, lastMainContent }

--- a/components/SideNavigationOverview.vue
+++ b/components/SideNavigationOverview.vue
@@ -270,6 +270,7 @@ export default {
     overflow-x: scroll;
     height: calc(100vh - 80px);
     padding: 0 10px;
+    width: 100%;
   }
   .SideNav-MainContent-Wrapper {
     margin-bottom: 20px;

--- a/components/SideNavigationOverview.vue
+++ b/components/SideNavigationOverview.vue
@@ -167,11 +167,11 @@ export default {
       for (let i = 0; i < mainCategoriesCount; i++) {
         const offsetHeight = this.$refs.mainContents[i]?.offsetHeight || 0
         allScrollTops.push(top)
-        top += offsetHeight + MARGIN
         if (i === mainCategoriesCount - 1) {
           lastMainContent.top = top
           lastMainContent.height = offsetHeight
         }
+        top += offsetHeight + MARGIN
       }
       return { allScrollTops, lastMainContent }
     },
@@ -180,12 +180,12 @@ export default {
     },
     getScrollLength() {
       // Add extra spacing to the last item so that the last content can fully scroll to top
-      const extraSpaceToExpandLastItem = this.sideNavigationOverviewIsShown()
-        ? 1.65
-        : 1.21
-      const scrollLength =
-        this.lastMainContent.top +
-        this.lastMainContent.height * extraSpaceToExpandLastItem
+      const scrollWindowHeight = this.$refs.contentArea.offsetHeight
+      const extraSpaceToExpandLastItem = Math.max(
+        this.lastMainContent.height,
+        scrollWindowHeight
+      )
+      const scrollLength = this.lastMainContent.top + extraSpaceToExpandLastItem
 
       return `${scrollLength}px`
     },


### PR DESCRIPTION
Issue #750 

This is an attempt at reusing the SideNavigationOverview component for the "County Info" page. 

The previous implementation used DOM ids for navigation but since those elements still exist on the page when switching tabs using refs to navigate and identify topics might work better.

The scroll length is also updated more frequently, this was originally to accommodate switching between counties in the tab but also seems to be useful when expanding questions in the FAQ. 

https://user-images.githubusercontent.com/52506986/103691804-a982df80-4f4b-11eb-8633-0b9dce3be3ad.mp4

