### PR TITLE
Add date range selection to county comparison chart

### DIFF
--- a/components/TimeLineChartCountyComparison.vue
+++ b/components/TimeLineChartCountyComparison.vue
@@ -76,95 +76,75 @@ export default {
     }
   },
   data() {
+    const caseData = {}
+    const percentData = {}
+    for (const county in this.chartData) {
+      const confirmedDailyIn14daysQueue = []
+      caseData[county] = this.chartData[county].graph.map(d => {
+        // calculate new cases per 100,000 residents (14 day average)
+        confirmedDailyIn14daysQueue.push(d.confirmedTransition)
+        if (confirmedDailyIn14daysQueue.length > 14) {
+          confirmedDailyIn14daysQueue.shift()
+        }
+        const averageDailyCases =
+          confirmedDailyIn14daysQueue.reduce((pre, curr) => {
+            return pre + curr
+          }, 0) / confirmedDailyIn14daysQueue.length
+        return averageDailyCases / (this.chartData[county].population / 100000)
+      })
+
+      const confirmedCumulativeIn7daysQueue = []
+      percentData[county] = this.chartData[county].graph.map(d => {
+        confirmedCumulativeIn7daysQueue.push(d.cumulative)
+        if (confirmedCumulativeIn7daysQueue.length > 7) {
+          const confirmedCumulative7daysBefore = confirmedCumulativeIn7daysQueue.shift()
+          return (
+            ((d.cumulative - confirmedCumulative7daysBefore) /
+              confirmedCumulative7daysBefore) *
+            100
+          )
+        } else {
+          return null
+        }
+      })
+    }
     return {
-      timePickerSelected: '30'
+      timePickerSelected: '30',
+      caseData,
+      percentData
     }
   },
   computed: {
     displayData() {
       if (this.selectedCounties.length) {
         const dataSets = []
-        if (this.chartDataType === 'casesperpeople') {
-          for (const county of this.selectedCounties) {
-            const confirmedDailyIn14daysQueue = []
-            dataSets.push({
-              type: 'line',
-              fill: false,
-              borderWidth: 3,
-              pointBackgroundColor: 'rgba(0,0,0,0)',
-              pointBorderColor: 'rgba(0,0,0,0)',
-              borderColor: county.color,
-              lineTension: 0.5,
-              borderJoinStyle: 'round',
-              label: county.name,
-              data: this.sliceToTimePick(this.chartData[county.name].graph).map(
-                d => {
-                  // calculate new cases per 100,000 residents (14 day average)
-                  confirmedDailyIn14daysQueue.push(d.confirmedTransition)
-                  if (confirmedDailyIn14daysQueue.length > 14) {
-                    confirmedDailyIn14daysQueue.shift()
-                  }
-                  const averageDailyCases =
-                    confirmedDailyIn14daysQueue.reduce((pre, curr) => {
-                      return pre + curr
-                    }, 0) / confirmedDailyIn14daysQueue.length
-                  return (
-                    averageDailyCases /
-                    (this.chartData[county.name].population / 100000)
-                  )
-                }
-              )
-            })
+        const data =
+          this.chartDataType === 'casesperpeople'
+            ? this.caseData
+            : this.percentData
+        const labels = this.chartData[this.selectedCounties[0].name].graph.map(
+          d => {
+            return d.label
           }
+        )
+        for (const county of this.selectedCounties) {
+          dataSets.push({
+            type: 'line',
+            fill: false,
+            borderWidth: 3,
+            pointBackgroundColor: 'rgba(0,0,0,0)',
+            pointBorderColor: 'rgba(0,0,0,0)',
+            borderColor: county.color,
+            lineTension: 0.5,
+            borderJoinStyle: 'round',
+            label: county.name,
+            data: this.sliceToTimePick(data[county.name])
+          })
+        }
 
-          return {
-            labels: this.sliceToTimePick(
-              this.chartData[this.selectedCounties[0].name].graph
-            ).map(d => {
-              return d.label
-            }),
-            datasets: dataSets
-          }
-        } else {
-          // Percent Increase in 7 days
-          for (const county of this.selectedCounties) {
-            const confirmedCumulativeIn7daysQueue = []
-            dataSets.push({
-              type: 'line',
-              fill: false,
-              borderWidth: 3,
-              pointBackgroundColor: 'rgba(0,0,0,0)',
-              pointBorderColor: 'rgba(0,0,0,0)',
-              borderColor: county.color,
-              lineTension: 0.5,
-              borderJoinStyle: 'round',
-              label: county.name,
-              data: this.sliceToTimePick(
-                this.chartData[county.name].graph.map(d => {
-                  confirmedCumulativeIn7daysQueue.push(d.cumulative)
-                  if (confirmedCumulativeIn7daysQueue.length > 7) {
-                    const confirmedCumulative7daysBefore = confirmedCumulativeIn7daysQueue.shift()
-                    return (
-                      ((d.cumulative - confirmedCumulative7daysBefore) /
-                        confirmedCumulative7daysBefore) *
-                      100
-                    )
-                  } else {
-                    return null
-                  }
-                })
-              )
-            })
-          }
-
-          return {
-            labels: this.sliceToTimePick(
-              this.chartData[this.selectedCounties[0].name].graph
-            ).map(d => {
-              return d.label
-            }),
-            datasets: dataSets
-          }
+        return {
+          labels: this.sliceToTimePick(labels),
+          datasets: dataSets
         }
       } else {
         return {

--- a/components/TimeLineChartCountyComparison.vue
+++ b/components/TimeLineChartCountyComparison.vue
@@ -127,6 +127,9 @@ export default {
             return d.label
           }
         )
+        const sliceToTimePick = arr =>
+          arr.slice(-Number(this.timePickerSelected) || 0)
+
         for (const county of this.selectedCounties) {
           dataSets.push({
             type: 'line',
@@ -138,12 +141,12 @@ export default {
             lineTension: 0.5,
             borderJoinStyle: 'round',
             label: county.name,
-            data: this.sliceToTimePick(data[county.name])
+            data: sliceToTimePick(data[county.name])
           })
         }
 
         return {
-          labels: this.sliceToTimePick(labels),
+          labels: sliceToTimePick(labels),
           datasets: dataSets
         }
       } else {
@@ -244,9 +247,6 @@ export default {
   methods: {
     handleTimePick(timePickerSelected) {
       this.timePickerSelected = timePickerSelected
-    },
-    sliceToTimePick(chartData) {
-      return chartData.slice(-Number(this.timePickerSelected) || 0)
     }
   }
 }


### PR DESCRIPTION
Issue #820 

Added dropdowns to the county comparison chart. 

![Screenshot from 2021-01-11 10-49-04](https://user-images.githubusercontent.com/52506986/104225076-bd6e8b80-53fa-11eb-9e20-3460cd10fb29.png)


- Thinking to add the dropdown to COVID ICU Care and Capacity as well 
- Since percent and rolling average data only needs to be calculated once for each county those calculations could be moved to data() but I'm not sure if that's the best place