### PR TITLE
Feature/issue907

### DIFF
--- a/components/Stats.vue
+++ b/components/Stats.vue
@@ -388,7 +388,7 @@ export default {
           {
             title: 'What this graph shows',
             description:
-              'This graph shows the ICU capacity and number of COVID ICU patients in the selected county. Use the control buttons to toggle each metric on or off.'
+              'This graph shows the number of suspected and confirmed COVID ICU patients, and the number of available ICU beds (including neonatal, pediatric, and adult ICU) in the selected county. Use the control buttons to toggle each metric on or off.'
           }
         ],
         casesPerResidents: [

--- a/components/Stats.vue
+++ b/components/Stats.vue
@@ -171,6 +171,7 @@
               renameCountyNameForHospitalization(currentCounty)
             ].graph
           "
+          :chart-info="chartInfo.icuCareCapacity"
           :date="
             CountyDataHospitalization[
               renameCountyNameForHospitalization(currentCounty)
@@ -381,6 +382,13 @@ export default {
             title: 'What this graph shows',
             description:
               'Showing cases per 1000 people normalizes the data for population size. This measure reflects the relative prevelance of COVID-19 cases by race and ethnicity. This data is calculated based on US census population data and confirmed cases that registered racial/ethnic data.'
+          }
+        ],
+        icuCareCapacity: [
+          {
+            title: 'What this graph shows',
+            description:
+              'This graph shows the ICU capacity and number of COVID ICU patients in the selected county. Use the control buttons to toggle each metric on or off.'
           }
         ],
         casesPerResidents: [

--- a/components/TimeLineChart.vue
+++ b/components/TimeLineChart.vue
@@ -5,6 +5,14 @@
     :date="date.split('T')[0]"
     :url="url"
   >
+    <template v-slot:button>
+      <TimePickerDropdown
+        class="dropdown-container"
+        :time-picker-model="timePickerSelected"
+        @timePickerSelected="handleTimePick"
+      />
+    </template>
+
     <bar
       :chart-id="chartId"
       :chart-data="displayData"
@@ -24,9 +32,10 @@
 <script>
 import DataView from '@/components/DataView.vue'
 import DataViewBasicInfoPanel from '@/components/DataViewBasicInfoPanel.vue'
+import TimePickerDropdown from '@/components/TimePickerDropdown'
 
 export default {
-  components: { DataView, DataViewBasicInfoPanel },
+  components: { DataView, DataViewBasicInfoPanel, TimePickerDropdown },
   props: {
     title: {
       type: String,
@@ -65,7 +74,7 @@ export default {
     }
   },
   data() {
-    return {}
+    return { timePickerSelected: '30' }
   },
   computed: {
     displayInfo() {
@@ -76,8 +85,9 @@ export default {
       }
     },
     displayData() {
+      const data = this.chartData.slice(-Number(this.timePickerSelected) || 0)
       return {
-        labels: this.chartData.map(d => {
+        labels: data.map(d => {
           return d.label
         }),
         datasets: [
@@ -88,7 +98,7 @@ export default {
             lineTension: 0.5,
             borderJoinStyle: 'round',
             label: 'COVID ICU patients',
-            data: this.chartData.map(d => {
+            data: data.map(d => {
               return d.icuConfirmed
             }),
             backgroundColor: '#453D88'
@@ -100,7 +110,7 @@ export default {
             lineTension: 0.5,
             borderJoinStyle: 'round',
             label: 'ICU Beds Available',
-            data: this.chartData.map(d => {
+            data: data.map(d => {
               return d.icuAvailable
             }),
             backgroundColor: '#AFACCA'
@@ -196,6 +206,11 @@ export default {
           ]
         }
       }
+    }
+  },
+  methods: {
+    handleTimePick(timePickerSelected) {
+      this.timePickerSelected = timePickerSelected
     }
   }
 }

--- a/components/TimeLineChart.vue
+++ b/components/TimeLineChart.vue
@@ -4,8 +4,26 @@
     :title-id="titleId"
     :date="date.split('T')[0]"
     :url="url"
+    :chart-info="chartInfo"
   >
     <template v-slot:button>
+      <v-btn
+        v-for="dataset in datasets"
+        :key="dataset.id"
+        outlined
+        class="data-selector-button"
+        :style="{
+          'background-color': dataset.active
+            ? dataset.backgroundColor
+            : 'white',
+          color: dataset.active ? 'white' : 'black'
+        }"
+        small
+        type="button"
+        @click="toggleActive(dataset)"
+      >
+        {{ dataset.label }}
+      </v-btn>
       <TimePickerDropdown
         class="dropdown-container"
         :time-picker-model="timePickerSelected"
@@ -57,6 +75,11 @@ export default {
       required: false,
       default: () => []
     },
+    chartInfo: {
+      type: Array,
+      required: false,
+      default: () => []
+    },
     date: {
       type: String,
       required: true,
@@ -74,7 +97,21 @@ export default {
     }
   },
   data() {
-    return { timePickerSelected: '30' }
+    const datasets = [
+      {
+        label: 'COVID ICU Patients',
+        backgroundColor: '#453D88',
+        active: true,
+        id: 'icuConfirmed'
+      },
+      {
+        label: 'ICU Beds Available',
+        backgroundColor: '#AFACCA',
+        active: false,
+        id: 'icuAvailable'
+      }
+    ]
+    return { timePickerSelected: '30', datasets }
   },
   computed: {
     displayInfo() {
@@ -90,32 +127,19 @@ export default {
         labels: data.map(d => {
           return d.label
         }),
-        datasets: [
-          {
-            type: 'line',
-            pointBackgroundColor: 'rgba(0,0,0,0)',
-            pointBorderColor: 'rgba(0,0,0,0)',
-            lineTension: 0.5,
-            borderJoinStyle: 'round',
-            label: 'COVID ICU patients',
-            data: data.map(d => {
-              return d.icuConfirmed
-            }),
-            backgroundColor: '#453D88'
-          },
-          {
-            type: 'line',
-            pointBackgroundColor: 'rgba(0,0,0,0)',
-            pointBorderColor: 'rgba(0,0,0,0)',
-            lineTension: 0.5,
-            borderJoinStyle: 'round',
-            label: 'ICU Beds Available',
-            data: data.map(d => {
-              return d.icuAvailable
-            }),
-            backgroundColor: '#AFACCA'
-          }
-        ]
+        datasets: this.datasets
+          .filter(d => d.active)
+          .map(dataset => {
+            const displayOptions = {
+              type: 'line',
+              pointBackgroundColor: 'rgba(0,0,0,0)',
+              pointBorderColor: 'rgba(0,0,0,0)',
+              lineTension: 0.5,
+              borderJoinStyle: 'round',
+              data: data.map(d => d[dataset.id])
+            }
+            return Object.assign({}, dataset, displayOptions)
+          })
       }
     },
     displayOption() {
@@ -125,12 +149,9 @@ export default {
           intersect: false,
           callbacks: {
             label(tooltipItem, data) {
-              const icuConfirmed = data.datasets[0].data[tooltipItem.index]
-              const icuBedAvailable = data.datasets[1].data[tooltipItem.index]
-              return [
-                'COVID ICU Patients: ' + icuConfirmed,
-                'ICU Bed Available: ' + icuBedAvailable
-              ]
+              return data.datasets.map(
+                d => `${d.label}: ${d.data[tooltipItem.index]}`
+              )
             },
             title(tooltipItem, data) {
               return data.labels[tooltipItem[0].index]
@@ -140,7 +161,7 @@ export default {
         responsive: true,
         maintainAspectRatio: false,
         legend: {
-          display: true
+          display: false
         },
         scales: {
           xAxes: [
@@ -211,13 +232,16 @@ export default {
   methods: {
     handleTimePick(timePickerSelected) {
       this.timePickerSelected = timePickerSelected
+    },
+    toggleActive(dataset) {
+      dataset.active = !dataset.active
     }
   }
 }
 </script>
 
 <style lang="scss" scoped>
-.selectorButton {
-  margin-top: 24px;
+.data-selector-button {
+  margin: 0.2rem;
 }
 </style>

--- a/components/TimeLineChart.vue
+++ b/components/TimeLineChart.vue
@@ -244,4 +244,7 @@ export default {
 .data-selector-button {
   margin: 0.2rem;
 }
+.dropdown-container {
+  margin-top: 24px;
+}
 </style>

--- a/utils/formatCountyHospitalizationData.ts
+++ b/utils/formatCountyHospitalizationData.ts
@@ -34,9 +34,7 @@ type CountyMapType = {
 
 const formatHospitalizationDataGraph = (data: HospitalizationDataType[]) => {
   const graphData: GraphDataType[] = []
-  const today = new Date()
-  const lastMonth = new Date()
-  lastMonth.setMonth(today.getMonth() - 3)
+  const lastMonth = new Date('2020-01-23')
   data
     .filter(d => new Date(d.date) > lastMonth)
     .forEach(d => {


### PR DESCRIPTION
Issue #907 

- Switched graph display options to button pattern from the county comparison charts
- Added chart info
- Added timeframe dropdown

There's already code in place to be able to display capacity in the upper right. I'm not sure where I should be pulling that from though since I'm not finding data that reflects what's [here](https://data.sfgov.org/stories/s/Hospital-Capacity/qtdt-yqr2/).

I also resized the buttons a bit so that they were more in line with the dropdown.

Curious what your thoughts are and feedback is greatly appreciated!

![Screenshot from 2021-01-28 18-12-52](https://user-images.githubusercontent.com/52506986/106222620-c4382500-6194-11eb-98e5-4494fba7fd9b.png)
![Screenshot from 2021-01-28 18-13-01](https://user-images.githubusercontent.com/52506986/106222623-c5695200-6194-11eb-91f6-6cbc0604f34d.png)
![Screenshot from 2021-01-28 18-13-09](https://user-images.githubusercontent.com/52506986/106222628-c69a7f00-6194-11eb-8464-8545fe72b642.png)
![Screenshot from 2021-01-28 18-14-27](https://user-images.githubusercontent.com/52506986/106222632-c7cbac00-6194-11eb-9d8d-01ad6ad22120.png)


