### PR TITLE
Make data update workflows manually triggerable

### DIFF
--- a/.github/workflows/data_update.yml
+++ b/.github/workflows/data_update.yml
@@ -4,6 +4,7 @@ on:
   schedule:
     # Run every 8 hours
     - cron: 0 */8 * * *
+  workflow_dispatch: {}
 
 jobs:
   # This workflow contains a single job called "build"

--- a/.github/workflows/data_update_hospitalization.yml
+++ b/.github/workflows/data_update_hospitalization.yml
@@ -4,6 +4,7 @@ on:
   schedule:
     # Run every 8 hours
     - cron: 0 */8 * * *
+  workflow_dispatch: {}
 
 jobs:
   # This workflow contains a single job called "build"

--- a/.github/workflows/data_update_v2.yml
+++ b/.github/workflows/data_update_v2.yml
@@ -4,6 +4,7 @@ on:
   schedule:
     # Run at 3 AM PDT every day
     - cron: 0 10 * * *
+  workflow_dispatch: {}
 
 jobs:
   # This workflow contains a single job called "build"

--- a/.github/workflows/news_update.yml
+++ b/.github/workflows/news_update.yml
@@ -4,6 +4,7 @@ on:
   schedule:
     # Run every 3 hours
     - cron: 0 */3 * * *
+  workflow_dispatch: {}
 
 jobs:
   # This workflow has only one job.


### PR DESCRIPTION
When we make hotfixes or other changes to the data scrapers, it would often be nice to be able to manually trigger a new workflow run instead of having to wait for the next scheduled run, which could be up to 24 hours away. This makes that possible.

When this is merged, you’ll see an option to manually trigger a workflow run when you go to the “Actions” tab and select one of the workflows from the list in the sidebar:

<img width="1089" alt="Screen Shot 2021-05-05 at 8 01 15 PM" src="https://user-images.githubusercontent.com/74178/117236416-7bb88500-addd-11eb-9c02-894df97dfa51.png">

(Screenshot from another project I contribute to that uses this feature.)
