### PR TITLE
Feature/issue1151

### DIFF
--- a/components/DataView.vue
+++ b/components/DataView.vue
@@ -47,7 +47,7 @@
         target="_blank"
         rel="noopener"
       >
-        {{ $t('Link to the Open Data Source') }}
+        {{ 'Link to the Open Data Source' }}
         <v-icon class="ExternalLinkIcon" size="15">mdi-open-in-new</v-icon>
       </a>
     </v-footer>

--- a/components/DataView.vue
+++ b/components/DataView.vue
@@ -14,8 +14,8 @@
         <span
           :class="{ 'infoIcon-visible': chartInfo }"
           class="infoIcon"
-          @mouseenter="showInfo()"
-          @mouseleave="hideInfo()"
+          @mouseover="showInfo()"
+          @mouseout="hideInfo()"
         >
           <InfoOutlineIcon />
         </span>

--- a/components/DataView.vue
+++ b/components/DataView.vue
@@ -14,8 +14,8 @@
         <span
           :class="{ 'infoIcon-visible': chartInfo }"
           class="infoIcon"
-          @mouseover="showInfo()"
-          @mouseout="hideInfo()"
+          @mouseenter="showInfo()"
+          @mouseleave="hideInfo()"
         >
           <InfoOutlineIcon />
         </span>

--- a/components/HorizontalBarChart.vue
+++ b/components/HorizontalBarChart.vue
@@ -48,8 +48,7 @@ export default {
     },
     chartInfo: {
       type: Array,
-      required: false,
-      default: () => []
+      required: false
     },
     date: {
       type: String,

--- a/components/ShareWidget.vue
+++ b/components/ShareWidget.vue
@@ -92,7 +92,6 @@ export default {
   box-sizing: inherit;
   width: 100%;
   position: fixed;
-  bottom: 0px;
   z-index: 100;
 }
 .row {
@@ -155,7 +154,7 @@ a:hover {
   }
   .index {
     /* Used to align bottom of ShareWidget with bottom of cards on index page */
-    height: calc(100% - 225px);
+    top: 225px;
   }
   .indexPad {
     /* Padding for when emailWidget is not available */
@@ -163,7 +162,7 @@ a:hover {
   }
   .main {
     /* Used to center ShareWidget within background-wrapper on main and about pages */
-    height: calc(100% - 95px);
+    top: 95px;
   }
   .mainPad {
     /* Padding for when emailWidget is not available */

--- a/components/Stats.vue
+++ b/components/Stats.vue
@@ -21,6 +21,7 @@
           :chart-data-type="'cases'"
           :date="CountyData.totals.lastUpdatedAt"
           :url="'https://coronadatascraper.com'"
+          :projection-start="lastDateWithAllCountyData"
         />
       </v-col>
       <v-col cols="12" md="6" class="DataCard">
@@ -32,6 +33,7 @@
           :chart-data-type="'deaths'"
           :date="CountyData.totals.lastUpdatedAt"
           :url="'https://coronadatascraper.com'"
+          :projection-start="lastDateWithAllCountyData"
         />
       </v-col>
       <!-- County Selector & Stats Card -->
@@ -248,6 +250,7 @@
           :date="CountyData[currentCounty].lastUpdatedAt"
           :url="'https://coronadatascraper.com'"
           :overlays="countyCompareOverlays"
+          :projection-start="lastDateWithAllCountyData"
         />
       </v-col>
       <v-col
@@ -269,6 +272,7 @@
             ...countyCompareOverlays,
             ...{ tiers: { selected: false } }
           }"
+          :projection-start="lastDateWithAllCountyData"
         />
       </v-col>
     </v-row>
@@ -311,6 +315,15 @@ export default {
     const countyNames = Object.values(DataVTwo)
       .map(({ name }) => name)
       .filter(name => name !== 'Bay Area Average')
+    const lastDateWithAllCountyData = Object.values(CountyData).reduce(
+      (dateLabel, county) => {
+        const lastDateLabel = county.graph.slice(-1)[0].label
+        return new Date(lastDateLabel) < new Date(dateLabel)
+          ? lastDateLabel
+          : dateLabel
+      },
+      '1/1/3000'
+    )
 
     const totalCases = CountyData.totals.cases.slice(-1)[0].cumulative
     const totalDeaths = CountyData.totals.cases.slice(-1)[0].deathCumulative
@@ -347,7 +360,8 @@ export default {
       totalDeaths,
       selectedCounties,
       countyCompareOverlays,
-      chartInfo
+      chartInfo,
+      lastDateWithAllCountyData
     }
 
     return data

--- a/components/Stats.vue
+++ b/components/Stats.vue
@@ -445,7 +445,7 @@ export default {
           {
             title: 'How are the projected totals calculated?',
             description:
-              'Counties that have not yet reported data are projected to continue reporting new cases and deaths at the same rate as their current 7 day average.'
+              'For each date confirmed numbers from counties that have reported data are added to projected numbers for those that have not. Counties that have not reported data are assumed to keep reporting at the same rate as their current 7 day average.'
           }
         ]
       }

--- a/components/Stats.vue
+++ b/components/Stats.vue
@@ -19,6 +19,7 @@
           :chart-id="'time-bar-chart-patients'"
           :chart-data="CountyData.totals.cases"
           :chart-data-type="'cases'"
+          :chart-info="chartInfo.bayAreaTotal"
           :date="CountyData.totals.lastUpdatedAt"
           :url="'https://coronadatascraper.com'"
           :projection-start="lastDateWithAllCountyData"
@@ -31,6 +32,7 @@
           :chart-id="'time-bar-chart-patients'"
           :chart-data="CountyData.totals.cases"
           :chart-data-type="'deaths'"
+          :chart-info="chartInfo.bayAreaTotal"
           :date="CountyData.totals.lastUpdatedAt"
           :url="'https://coronadatascraper.com'"
           :projection-start="lastDateWithAllCountyData"
@@ -265,6 +267,7 @@
           :chart-data="CountyData"
           :selected-counties="selectedCounties"
           :chart-data-type="'percentincrease'"
+          :chart-info="chartInfo.percentIncrease7Days"
           :date="CountyData[currentCounty].lastUpdatedAt"
           :unit="'%'"
           :url="'https://coronadatascraper.com'"
@@ -424,6 +427,25 @@ export default {
             title: 'Why a 7 day average?',
             description:
               'Showing an average value smooths the data curve and makes trends easier to observe.'
+          },
+          {
+            title: 'How is the Projected Bay Area Average calculated?',
+            description:
+              'In calculating totals for the Projected Bay Area Average counties that have not yet reported data are assumed to continue reporting new cases and deaths at the same rate as their current 7 day average.'
+          }
+        ],
+        percentIncrease7Days: [
+          {
+            title: 'How is the Projected Bay Area Average calculated?',
+            description:
+              'In calculating totals for the Projected Bay Area Average counties that have not yet reported data are assumed to continue reporting new cases and deaths at the same rate as their current 7 day average.'
+          }
+        ],
+        bayAreaTotal: [
+          {
+            title: 'How are the projected totals calculated?',
+            description:
+              'Counties that have not yet reported data are projected to continue reporting new cases and deaths at the same rate as their current 7 day average.'
           }
         ]
       }

--- a/components/TimeBarChart.vue
+++ b/components/TimeBarChart.vue
@@ -162,7 +162,7 @@ export default {
     displayData() {
       this.updateChartDataByTimePick()
       const colors = this.chartDataClone.map(({ label }) =>
-        new Date(label) < new Date(this.projectionStart) ? '#473A8C' : '#7d70bb'
+        new Date(label) > new Date(this.projectionStart) ? '#7d70bb' : '#473A8C'
       )
       if (this.dataKind === 'confirmedTransition') {
         return {

--- a/components/TimeBarChart.vue
+++ b/components/TimeBarChart.vue
@@ -171,45 +171,39 @@ export default {
     },
     displayData() {
       this.updateChartDataByTimePick()
-      const colors = this.chartDataClone.map(({ label }) =>
-        new Date(label) > new Date(this.projectionStart) ? '#7d70bb' : '#473A8C'
+      const confirmed = this.chartDataClone.map(
+        ({ label }) => !(new Date(label) > new Date(this.projectionStart))
       )
-      if (this.dataKind === 'confirmedTransition') {
-        return {
-          labels: this.chartDataClone.map(d => {
-            return d.label
-          }),
-          datasets: [
-            {
-              data: this.chartDataClone.map(d => {
-                if (this.chartDataType === 'cases') {
-                  return d.confirmedTransition
-                } else if (this.chartDataType === 'deaths') {
-                  return d.deathTransition
-                }
-              }),
-              backgroundColor: colors
-            }
-          ]
-        }
+      const data = this.chartDataClone.map(d => {
+        return this.dataKind === 'confirmedTransition'
+          ? this.chartDataType === 'cases'
+            ? d.confirmedTransition
+            : d.deathTransition
+          : this.chartDataType === 'cases'
+          ? d.cumulative
+          : d.deathCumulative
+      })
+      const labels = this.chartDataClone.map(d => {
+        return d.label
+      })
+      const dataConfig = {
+        data,
+        categoryPercentage: 0.1
       }
       return {
-        labels: this.chartDataClone.map(d => {
-          return d.label
-        }),
+        labels,
         datasets: [
           {
-            data: this.chartDataClone.map(d => {
-              if (this.chartDataType === 'cases') {
-                return d.cumulative
-              } else if (this.chartDataType === 'deaths') {
-                return d.deathCumulative
-              } else {
-                return null
-              }
-            }),
+            ...dataConfig,
+            label: 'Confirmed',
             backgroundColor: '#473A8C',
-            borderWidth: 0
+            barPercentage: confirmed.map(isConfirmed => (isConfirmed ? 15 : 0))
+          },
+          {
+            ...dataConfig,
+            label: 'Projected',
+            backgroundColor: '#7d70bb',
+            barPercentage: confirmed.map(isConfirmed => (isConfirmed ? 0 : 15))
           }
         ]
       }
@@ -234,7 +228,7 @@ export default {
         responsive: true,
         maintainAspectRatio: false,
         legend: {
-          display: false
+          display: this.title.match('Bay Area Total')
         },
         scales: {
           xAxes: [

--- a/components/TimeBarChart.vue
+++ b/components/TimeBarChart.vue
@@ -1,5 +1,11 @@
 <template>
-  <data-view :title="title" :title-id="titleId" :date="date" :url="url">
+  <data-view
+    :title="title"
+    :title-id="titleId"
+    :date="date"
+    :url="url"
+    :chart-info="chartInfo"
+  >
     <template v-slot:button>
       <data-selector v-model="dataKind" class="selectorButton" />
       <TimePickerDropdown
@@ -81,6 +87,10 @@ export default {
       type: String,
       required: false,
       default: '1/1/3000'
+    },
+    chartInfo: {
+      type: Array,
+      required: false
     }
   },
   data() {

--- a/components/TimeBarChart.vue
+++ b/components/TimeBarChart.vue
@@ -76,6 +76,11 @@ export default {
       type: String,
       required: false,
       default: ''
+    },
+    projectionStart: {
+      type: String,
+      required: false,
+      default: '1/1/3000'
     }
   },
   data() {
@@ -156,6 +161,9 @@ export default {
     },
     displayData() {
       this.updateChartDataByTimePick()
+      const colors = this.chartDataClone.map(({ label }) =>
+        new Date(label) < new Date(this.projectionStart) ? '#473A8C' : '#7d70bb'
+      )
       if (this.dataKind === 'confirmedTransition') {
         return {
           labels: this.chartDataClone.map(d => {
@@ -170,7 +178,7 @@ export default {
                   return d.deathTransition
                 }
               }),
-              backgroundColor: '#473A8C'
+              backgroundColor: colors
             }
           ]
         }

--- a/components/TimeLineChartCountyComparison.vue
+++ b/components/TimeLineChartCountyComparison.vue
@@ -79,6 +79,11 @@ export default {
       type: Object,
       required: false,
       default: () => Object()
+    },
+    projectionStart: {
+      type: String,
+      required: false,
+      default: '1/1/3000'
     }
   },
   data() {
@@ -206,18 +211,52 @@ export default {
         const sliceToTimePick = arr => arr.slice(timePickIndex)
 
         for (const county of countiesToDisplay) {
-          dataSets.push({
-            type: 'line',
-            fill: false,
-            borderWidth: 3,
-            pointBackgroundColor: 'rgba(0,0,0,0)',
-            pointBorderColor: 'rgba(0,0,0,0)',
-            borderColor: this.chartData[county].color,
-            lineTension: 0.5,
-            borderJoinStyle: 'round',
-            label: chartData[county].name,
-            data: sliceToTimePick(data[county])
-          })
+          if (county !== 'totals') {
+            dataSets.push({
+              type: 'line',
+              fill: false,
+              borderWidth: 3,
+              pointBackgroundColor: 'rgba(0,0,0,0)',
+              pointBorderColor: 'rgba(0,0,0,0)',
+              borderColor: this.chartData[county].color,
+              lineTension: 0.5,
+              borderJoinStyle: 'round',
+              label: chartData[county].name,
+              data: sliceToTimePick(data[county])
+            })
+          } else {
+            const confirmedData = data.totals.slice(
+              0,
+              chartData.totals.graph.findIndex(
+                ({ label }) => label === this.projectionStart
+              )
+            )
+            dataSets.push({
+              type: 'line',
+              fill: false,
+              borderWidth: 3,
+              pointBackgroundColor: 'rgba(0,0,0,0)',
+              pointBorderColor: 'rgba(0,0,0,0)',
+              borderColor: this.chartData[county].color,
+              lineTension: 0.5,
+              borderJoinStyle: 'round',
+              label: chartData[county].name,
+              data: sliceToTimePick(confirmedData)
+            })
+            dataSets.push({
+              type: 'line',
+              fill: false,
+              borderWidth: 3,
+              borderDash: [5, 5],
+              pointBackgroundColor: 'rgba(0,0,0,0)',
+              pointBorderColor: 'rgba(0,0,0,0)',
+              borderColor: '#777',
+              lineTension: 0.5,
+              borderJoinStyle: 'round',
+              label: 'Projected Bay Area Average',
+              data: sliceToTimePick(data[county])
+            })
+          }
         }
 
         return {

--- a/components/TimeLineChartCountyComparison.vue
+++ b/components/TimeLineChartCountyComparison.vue
@@ -57,8 +57,7 @@ export default {
     },
     chartInfo: {
       type: Array,
-      required: false,
-      default: () => []
+      required: false
     },
     date: {
       type: String,

--- a/components/TimeLineChartCountyComparison.vue
+++ b/components/TimeLineChartCountyComparison.vue
@@ -210,52 +210,38 @@ export default {
         const sliceToTimePick = arr => arr.slice(timePickIndex)
 
         for (const county of countiesToDisplay) {
-          if (county !== 'totals') {
-            dataSets.push({
-              type: 'line',
-              fill: false,
-              borderWidth: 3,
-              pointBackgroundColor: 'rgba(0,0,0,0)',
-              pointBorderColor: 'rgba(0,0,0,0)',
-              borderColor: this.chartData[county].color,
-              lineTension: 0.5,
-              borderJoinStyle: 'round',
-              label: chartData[county].name,
-              data: sliceToTimePick(data[county])
-            })
-          } else {
-            const confirmedData = data.totals.slice(
-              0,
+          const countyDataSet = {
+            type: 'line',
+            fill: false,
+            borderWidth: 3,
+            pointBackgroundColor: 'rgba(0,0,0,0)',
+            pointBorderColor: 'rgba(0,0,0,0)',
+            lineTension: 0.5,
+            borderJoinStyle: 'round',
+            borderColor: this.chartData[county].color,
+            label: chartData[county].name,
+            data: sliceToTimePick(data[county])
+          }
+          const projectionConfig = {
+            borderDash: [5, 5],
+            borderColor: '#777',
+            label: 'Projected Bay Area Average'
+          }
+
+          if (county === 'totals') {
+            const projectionStartIndex =
               chartData.totals.graph.findIndex(
                 ({ label }) => label === this.projectionStart
               ) + 1
-            )
+            const confirmedData = data.totals.slice(0, projectionStartIndex)
             dataSets.push({
-              type: 'line',
-              fill: false,
-              borderWidth: 3,
-              pointBackgroundColor: 'rgba(0,0,0,0)',
-              pointBorderColor: 'rgba(0,0,0,0)',
-              borderColor: this.chartData[county].color,
-              lineTension: 0.5,
-              borderJoinStyle: 'round',
-              label: chartData[county].name,
+              ...countyDataSet,
               data: sliceToTimePick(confirmedData)
             })
-            dataSets.push({
-              type: 'line',
-              fill: false,
-              borderWidth: 3,
-              borderDash: [5, 5],
-              pointBackgroundColor: 'rgba(0,0,0,0)',
-              pointBorderColor: 'rgba(0,0,0,0)',
-              borderColor: '#777',
-              lineTension: 0.5,
-              borderJoinStyle: 'round',
-              label: 'Projected Bay Area Average',
-              data: sliceToTimePick(data[county])
-            })
+            Object.assign(countyDataSet, projectionConfig)
           }
+
+          dataSets.push(countyDataSet)
         }
 
         return {

--- a/components/TimeLineChartCountyComparison.vue
+++ b/components/TimeLineChartCountyComparison.vue
@@ -229,7 +229,7 @@ export default {
               0,
               chartData.totals.graph.findIndex(
                 ({ label }) => label === this.projectionStart
-              )
+              ) + 1
             )
             dataSets.push({
               type: 'line',


### PR DESCRIPTION
* Adds projections to Bay Area Total and Bay Area Average graphs
* Adds legends for projectiots
* Adds descriptions for how projections are calculated
* Resizes container for share widget so it no longer blocks info overlays
* Resolves vue-i18n errors in the console

![Screenshot from 2021-05-20 17-45-56](https://user-images.githubusercontent.com/52506986/119065947-86554b80-b993-11eb-9864-d713c3de8714.png)
![Screenshot from 2021-05-20 17-45-31](https://user-images.githubusercontent.com/52506986/119065949-87867880-b993-11eb-83a6-ae7776d370b9.png)
